### PR TITLE
fix arithmetic on a nil value error when subscribing to topic $SYS/broker/clients/connected

### DIFF
--- a/lua/mqtt_library.lua
+++ b/lua/mqtt_library.lua
@@ -579,7 +579,7 @@ function MQTT.client:parse_message_publish(                     -- Internal API
     if (qos > 0) then
       local message_id = string.byte(message, index) * 256
       local byte_ret = string.byte(message, index + 1)
-	  if byte_ret ~= nil then message_id = message_id + byte_ret end
+      if byte_ret ~= nil then message_id = message_id + byte_ret end
       index = index + 2
     end
 

--- a/lua/mqtt_library.lua
+++ b/lua/mqtt_library.lua
@@ -578,7 +578,8 @@ function MQTT.client:parse_message_publish(                     -- Internal API
 
     if (qos > 0) then
       local message_id = string.byte(message, index) * 256
-      message_id = message_id + string.byte(message, index + 1)
+      local byte_ret = string.byte(message, index + 1)
+	  if byte_ret ~= nil then message_id = message_id + byte_ret end
       index = index + 2
     end
 


### PR DESCRIPTION
An error occurs in the context of clients subscribing to topic "$SYS/broker/clients/connected" in mosquitto server.

Verifying if the byte value (string.byte(message, index + 1)) is not nil is enough to avoid the error and subsequent program termination.